### PR TITLE
Transfer Copyright from Cornel Univesity to Lyrasis

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022, Cornell University
+Copyright (c) 2024, Lyrasis
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -9,7 +9,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
-    * Neither the name of Cornell University nor the names of its contributors
+    * Neither the name of Lyrasis nor the names of its contributors
       may be used to endorse or promote products derived from this software
       without specific prior written permission.
 


### PR DESCRIPTION
Transfer Copyright from Cornel Univesity to Lyrasis and update year to 2024
